### PR TITLE
feat/image-fallbacks

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -18,24 +18,28 @@ import {
   HERO_VALUE_SUBHEADLINE,
   THE_STANDARD_HOSTNAME,
 } from '@constants/index';
-import {
-  handleNewsImageLoadError,
-  publisherImageReferrerProps,
-  resolveImageUrl,
-} from '@utils/formatters';
+import { useFeaturedImageSrc } from '@hooks/use-featured-image-src';
+import { publisherImageReferrerProps, resolveImageUrl } from '@utils/formatters';
 import { Link } from 'react-router-dom';
 import type { HeroSectionProps } from 'types/hero.types';
 
 export function HeroSection({ featuredArticle }: HeroSectionProps) {
+  const resolvedHero = resolveImageUrl(featuredArticle.image);
+  const { src: heroImageSrc, onError: onHeroImageError } = useFeaturedImageSrc(
+    resolvedHero,
+    [],
+    featuredArticle.id,
+  );
+
   return (
     <section className={HERO_SECTION_ROOT_CLASS} aria-label='Featured coverage'>
       <img
-        src={resolveImageUrl(featuredArticle.image)}
+        src={heroImageSrc}
         alt={featuredArticle.title}
         loading='eager'
         fetchPriority='high'
         className={HERO_BACKGROUND_IMAGE_CLASS}
-        onError={handleNewsImageLoadError}
+        onError={onHeroImageError}
         {...publisherImageReferrerProps}
       />
       <div className={HERO_GRADIENT_OVERLAY_CLASS} aria-hidden='true' />

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -21,14 +21,14 @@ import {
   ROUTE_PATH_READ_PREFIX,
   ROUTE_STATE_NEWS_DESK_CATEGORY,
 } from '@constants/index';
+import { useFeaturedImageSrc } from '@hooks/use-featured-image-src';
 import {
   decodeHtmlEntities,
-  handleNewsImageLoadError,
   isStandardPublisherImageUrl,
   placeholderNewsPublicPath,
   publisherImageReferrerProps,
 } from '@utils/formatters';
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useMemo } from 'preact/hooks';
 import { Link } from 'react-router-dom';
 
 export interface NewsCardProps {
@@ -52,8 +52,6 @@ export function NewsCard({
   featuredMediaId,
   isFeature,
 }: NewsCardProps) {
-  const [imageSrc, setImageSrc] = useState(imageUrl);
-  const [candidateIndex, setCandidateIndex] = useState(0);
   const baseUrl = import.meta.env.BASE_URL ?? '/';
 
   const localCandidates = useMemo(() => {
@@ -70,10 +68,11 @@ export function NewsCard({
     ];
   }, [baseUrl, featuredMediaId, imageUrl]);
 
-  useEffect(() => {
-    setImageSrc(imageUrl);
-    setCandidateIndex(0);
-  }, [imageUrl, postId]);
+  const { src: imageSrc, onError: handleImageError } = useFeaturedImageSrc(
+    imageUrl,
+    localCandidates,
+    postId,
+  );
 
   const readPath = `${ROUTE_PATH_READ_PREFIX}${postId}`;
 
@@ -88,17 +87,6 @@ export function NewsCard({
   const titleClass = isFeature
     ? NEWS_CARD_TITLE_FEATURE_CLASS
     : NEWS_CARD_TITLE_STANDARD_CLASS;
-
-  const handleImageError = (event: { currentTarget: HTMLImageElement }): void => {
-    if (candidateIndex < localCandidates.length) {
-      const nextSrc = localCandidates[candidateIndex];
-      setCandidateIndex((idx) => idx + 1);
-      setImageSrc(nextSrc);
-      return;
-    }
-    handleNewsImageLoadError(event);
-    setImageSrc(placeholderNewsPublicPath());
-  };
 
   return (
     <li className={isFeature ? NEWS_CARD_FEATURE_LI_CLASS : ''}>

--- a/src/components/post.tsx
+++ b/src/components/post.tsx
@@ -7,16 +7,16 @@ import {
   ROUTE_PATH_NEWS_DESK_FALLBACK,
   ROUTE_STATE_NEWS_DESK_CATEGORY,
 } from '@constants/index';
+import { useFeaturedImageSrc } from '@hooks/use-featured-image-src';
 import useIntersectionObserver from '@hooks/use-intersection-observer';
 import {
   decodeHtmlEntities,
   isStandardPublisherImageUrl,
-  placeholderNewsPublicPath,
   publisherImageReferrerProps,
 } from '@utils/formatters';
 import { Fragment } from 'preact';
 import { memo } from 'preact/compat';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { Link } from 'react-router-dom';
 import type { WpRenderedContent, WpRenderedText } from 'types/wp-api';
 
@@ -50,8 +50,6 @@ function Post({ post, group }: PostProps) {
     stripHtml(post?.excerpt?.rendered ?? ''),
   ).trim();
   const usePlaceholder = group !== undefined && group !== 0 && !isVisible;
-  const [imageSrc, setImageSrc] = useState<string | undefined>(post.imageUrl);
-  const [candidateIndex, setCandidateIndex] = useState(0);
   const [showImageFallbackNote, setShowImageFallbackNote] = useState(false);
   const baseUrl = import.meta.env.BASE_URL ?? '/';
 
@@ -70,13 +68,20 @@ function Post({ post, group }: PostProps) {
     ];
   }, [baseUrl, post.featured_media, post.imageUrl]);
 
+  const onDeckPlaceholder = useCallback(() => setShowImageFallbackNote(true), []);
+
+  const { src: remoteSrc, onError: onRemoteImageError } = useFeaturedImageSrc(
+    post.imageUrl ?? '',
+    localCandidates,
+    post.id,
+    onDeckPlaceholder,
+  );
+
   useEffect(() => {
-    setImageSrc(post.imageUrl);
-    setCandidateIndex(0);
     setShowImageFallbackNote(false);
   }, [post.id, post.imageUrl]);
 
-  const resolvedSrc = usePlaceholder ? placeholderImage : imageSrc || placeholderImage;
+  const resolvedSrc = usePlaceholder ? placeholderImage : remoteSrc;
 
   return (
     <li className='h-full list-none'>
@@ -95,14 +100,8 @@ function Post({ post, group }: PostProps) {
             decoding='async'
             {...publisherImageReferrerProps}
             onError={(event) => {
-              if (candidateIndex < localCandidates.length) {
-                const nextSrc = localCandidates[candidateIndex];
-                setCandidateIndex((idx) => idx + 1);
-                setImageSrc(nextSrc);
-                return;
-              }
-              setShowImageFallbackNote(true);
-              event.currentTarget.src = placeholderNewsPublicPath();
+              if (usePlaceholder) return;
+              onRemoteImageError(event);
             }}
           />
         </div>

--- a/src/components/post.tsx
+++ b/src/components/post.tsx
@@ -81,7 +81,14 @@ function Post({ post, group }: PostProps) {
     setShowImageFallbackNote(false);
   }, [post.id, post.imageUrl]);
 
-  const resolvedSrc = usePlaceholder ? placeholderImage : remoteSrc;
+  const hasDeckImageAttempts =
+    Boolean((post.imageUrl ?? '').trim()) || localCandidates.length > 0;
+
+  const resolvedSrc = usePlaceholder
+    ? placeholderImage
+    : hasDeckImageAttempts
+      ? remoteSrc
+      : placeholderImage;
 
   return (
     <li className='h-full list-none'>
@@ -100,7 +107,7 @@ function Post({ post, group }: PostProps) {
             decoding='async'
             {...publisherImageReferrerProps}
             onError={(event) => {
-              if (usePlaceholder) return;
+              if (usePlaceholder || !hasDeckImageAttempts) return;
               onRemoteImageError(event);
             }}
           />

--- a/src/hooks/use-featured-image-src.ts
+++ b/src/hooks/use-featured-image-src.ts
@@ -1,0 +1,55 @@
+import {
+  buildFeaturedImageFallbackChain,
+  placeholderNewsPublicPath,
+} from '@utils/formatters';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+
+/**
+ * Cycles through {@link buildFeaturedImageFallbackChain} on `onError`, then
+ * `placeholder-news.jpg`. Updates `currentTarget.src` synchronously so the next
+ * candidate loads without waiting for React render.
+ */
+export function useFeaturedImageSrc(
+  resolvedPrimary: string,
+  localCandidates: readonly string[],
+  resetKey: string | number,
+  /** Invoked once when all candidates fail and the public placeholder is applied. */
+  onFallbackToPlaceholder?: () => void,
+) {
+  const fallbackCbRef = useRef(onFallbackToPlaceholder);
+  fallbackCbRef.current = onFallbackToPlaceholder;
+  const chain = useMemo(
+    () => buildFeaturedImageFallbackChain(resolvedPrimary, localCandidates),
+    [resolvedPrimary, localCandidates],
+  );
+
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    setIdx(0);
+  }, [resetKey, resolvedPrimary, chain]);
+
+  const src =
+    chain.length > 0
+      ? chain[Math.min(idx, chain.length - 1)]!
+      : placeholderNewsPublicPath();
+
+  const onError = useCallback(
+    (event: { currentTarget: HTMLImageElement }) => {
+      setIdx((current) => {
+        const next = current + 1;
+        if (next < chain.length) {
+          const nextSrc = chain[next];
+          if (nextSrc) event.currentTarget.src = nextSrc;
+          return next;
+        }
+        event.currentTarget.src = placeholderNewsPublicPath();
+        fallbackCbRef.current?.();
+        return Math.max(0, chain.length - 1);
+      });
+    },
+    [chain],
+  );
+
+  return { src, onError };
+}

--- a/src/pages/read-story.tsx
+++ b/src/pages/read-story.tsx
@@ -14,10 +14,10 @@
 import rawStoryPages from '@assets/cached/story-pages.json';
 import PageHeader from '@components/page-header';
 import { PUBLIC_SITE_URL } from '@constants/index';
+import { useFeaturedImageSrc } from '@hooks/use-featured-image-src';
 import { absoluteUrlForOpenGraph, usePageSeo } from '@hooks/use-page-seo';
 import {
   decodeHtmlEntities,
-  handleNewsImageLoadError,
   publisherImageReferrerProps,
   resolveImageUrl,
 } from '@utils/formatters';
@@ -56,6 +56,16 @@ function ReadStory() {
       .slice(0, 3)
       .map((item) => item.row);
   }, [story]);
+
+  const resolvedLeadImage = useMemo(
+    () => (story ? resolveImageUrl(story.imageUrl ?? '') : ''),
+    [story],
+  );
+  const { src: leadImageSrc, onError: onLeadImageError } = useFeaturedImageSrc(
+    resolvedLeadImage,
+    [],
+    story?.id ?? `read-${id ?? 'unknown'}`,
+  );
 
   /*
    * Story pages use `og:type: article` when `story` exists. `image` uses `resolveImageUrl`
@@ -125,10 +135,12 @@ function ReadStory() {
           ))}
         </div>
         <img
-          className='mt-5 w-full rounded-xl border border-white/20 bg-white/5 object-cover max-h-[28rem]'
-          src={resolveImageUrl(story.imageUrl ?? '')}
+          className='mt-5 w-full min-h-[12rem] rounded-xl border border-white/20 bg-neutral-800 object-cover max-h-[28rem]'
+          src={leadImageSrc}
           alt={story.title}
-          onError={handleNewsImageLoadError}
+          loading='eager'
+          decoding='async'
+          onError={onLeadImageError}
           {...publisherImageReferrerProps}
         />
         <div

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -70,3 +70,30 @@ export function handleNewsImageLoadError(event: {
 }): void {
   event.currentTarget.src = placeholderNewsPublicPath();
 }
+
+/**
+ * Ordered `src` attempts for featured images (plan.md PR 18).
+ * WordPress often exposes `-WxH` derivatives; loading the undimensioned file name can succeed
+ * when the cropped asset 404s or is blocked. Appends optional `cached-media/*` candidates.
+ */
+export function buildFeaturedImageFallbackChain(
+  resolvedPrimary: string,
+  localCandidates: readonly string[] = [],
+): string[] {
+  const raw = typeof resolvedPrimary === 'string' ? resolvedPrimary.trim() : '';
+  const chain: string[] = [];
+  if (raw) {
+    chain.push(raw);
+    if (isStandardPublisherImageUrl(raw)) {
+      const stripped = raw.replace(/-\d+x\d+(?=\.[a-z0-9]+(?:$|\?))/i, '');
+      if (stripped !== raw && stripped.length > 0 && !chain.includes(stripped)) {
+        chain.push(stripped);
+      }
+    }
+  }
+  for (const c of localCandidates) {
+    const t = typeof c === 'string' ? c.trim() : '';
+    if (t && !chain.includes(t)) chain.push(t);
+  }
+  return chain;
+}


### PR DESCRIPTION
### Summary
Centralizes featured-image recovery behind a shared fallback chain and a small hook so cards, hero, read-story lead art, and news-desk `Post` rows behave consistently when a primary URL fails (including WordPress-style `-WxH` derivatives and optional `cached-media/*` paths).

### What changed
- **`buildFeaturedImageFallbackChain`** (`formatters.ts`) — Builds an ordered list: trimmed primary → for `thestandard.co` URLs, a second URL with `-WxH` stripped before the extension → then any non-duplicate `localCandidates` (e.g. cached extensions).
- **`useFeaturedImageSrc`** — Tracks which chain entry is active; on `onError`, sets `currentTarget.src` to the next candidate synchronously, then **`placeholder-news.jpg`**. Optional **`onFallbackToPlaceholder`** runs when everything fails (used in **`Post`** for the “preview unavailable” note).
- **`NewsCard`** / **`HeroSection`** / **`read-story`** — Replace ad‑hoc or single-shot error handlers with the hook; read-story lead image gets **`loading='eager'`**, **`decoding='async'`**, and **`min-h-[12rem]`** + **`bg-neutral-800`** to reduce layout/black flash while loading.
- **`Post`** — Same hook + callback for the fallback note; when there is **no** remote URL **and** no cached-media candidates, keeps the bundled **`placeholder.png`** (lazy blur path unchanged) instead of switching to the public JPG placeholder.

### Testing
- `pnpm lint`
- `pnpm build`

### Notes
- **`handleNewsImageLoadError`** remains in formatters for any remaining callers; featured surfaces above use the hook instead.